### PR TITLE
fix(twwv): drop setAllowUniversalAccessFromFileURLs on the editor WebView

### DIFF
--- a/app/src/main/java/top/donmor/tiddloid/TWEditorWV.java
+++ b/app/src/main/java/top/donmor/tiddloid/TWEditorWV.java
@@ -316,7 +316,6 @@ public class TWEditorWV extends AppCompatActivity {
 		wvs.setAllowFileAccess(true);
 		wvs.setAllowContentAccess(true);
 		wvs.setAllowFileAccessFromFileURLs(true);
-		wvs.setAllowUniversalAccessFromFileURLs(true);
 		wvs.setSupportMultipleWindows(true);
 		wvs.setMediaPlaybackRequiresUserGesture(false);
 		if (MainActivity.isDebug(this)) WebView.setWebContentsDebuggingEnabled(true);    // 在debug环境启用调试


### PR DESCRIPTION
Closes #87.

\`TWEditorWV.onCreate\` configures the editor WebView with:


`wvs.setAllowFileAccess(true);`
`wvs.setAllowContentAccess(true);`
`wvs.setAllowFileAccessFromFileURLs(true);`
`wvs.setAllowUniversalAccessFromFileURLs(true);`


The first three are what a TiddlyWiki editor needs to load wiki files off device storage and let TiddlyWiki XHR its own bundled assets inside the same wiki. The fourth lets the \`file://\` page issue XHR against any other origin (\`https://...\`, `content://`, the app's data dir), which is the broad CWE-200 pattern Android docs flag.

Any wiki the user opens runs whatever JS is inside it under the file scheme, and with universal access turned on that JS can read across origins.

### Change

Drop the single line:


`- wvs.setAllowUniversalAccessFromFileURLs(true);`


TiddlyWiki keeps working because \`setAllowFileAccessFromFileURLs(true)\` already covers the only XHR target a wiki actually needs (other \`file://\` resources in the wiki package).